### PR TITLE
performance: avoid memory allocations with cast_to in binary operations

### DIFF
--- a/source/gc.hpp
+++ b/source/gc.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <concepts>
+#include <cstddef>
 #include <cstdlib>
 #include <utility>
 #include <vector>
@@ -8,21 +9,33 @@
 template<typename T>
 class gc
 {
+    using store = std::vector<T*>;
+
   public:
-    static void track(T* obj) { get_allocation_list().push_back(obj); }
+    static void track(T* obj) { get_store().push_back(obj); }
 
   private:
     static void cleanup()
     {
-        for (T* obj : get_allocation_list()) {
+        for (T* obj : get_store()) {
             delete obj;
         }
     }
 
-    static auto get_allocation_list() -> std::vector<T*>&
+    static auto get_store() -> store&
     {
-        static std::vector<T*> allocations;
-        static const bool registered = []() { return std::atexit(cleanup); }();
+        static store allocations;
+        static const bool registered = []()
+        {
+            if constexpr (std::is_same_v<T, struct object>) {
+                constexpr auto object_reserve = static_cast<const size_t>(64 * 1024 * 1024);
+                allocations.reserve(object_reserve);
+            } else {
+                constexpr auto reserve = static_cast<const size_t>(128);
+                allocations.reserve(reserve);
+            }
+            return std::atexit(cleanup);
+        }();
         (void)registered;
         return allocations;
     }

--- a/source/object/object.cpp
+++ b/source/object/object.cpp
@@ -75,7 +75,7 @@ auto value_eq_helper(const double& lhs, const double& rhs) -> const object*
 template<>
 auto eq_helper(const decimal_object* t, const object& other) -> const object*
 {
-    return native_bool_to_object(other.is(t->type()) && are_almost_equal(t->value, other.as<decimal_object>()->value));
+    return native_bool_to_object(other.is(t->type()) && are_almost_equal(t->value, other.val<decimal_object>()));
 }
 
 template<typename T>
@@ -217,7 +217,7 @@ auto string_object::operator>(const object& other) const -> const object*
 auto string_object::operator+(const object& other) const -> const object*
 {
     if (other.is(string)) {
-        return make<string_object>(value + other.as<string_object>()->value);
+        return make<string_object>(value + other.val<string_object>());
     }
     return nullptr;
 }
@@ -225,7 +225,7 @@ auto string_object::operator+(const object& other) const -> const object*
 auto string_object::operator*(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return multiply_sequence_helper(this, other.as<integer_object>()->value);
+        return multiply_sequence_helper(this, other.val<integer_object>());
     }
     return nullptr;
 }
@@ -238,10 +238,10 @@ auto boolean_object::hash_key() const -> key_type
 auto boolean_object::operator==(const object& other) const -> const object*
 {
     if (other.is(decimal)) {
-        return value_eq_helper(as_value_of<decimal_object, boolean_object>(), other.as<decimal_object>()->value);
+        return value_eq_helper(value_to<decimal_object>(), other.val<decimal_object>());
     }
     if (other.is(integer)) {
-        return value_eq_helper(as_value_of<integer_object, boolean_object>(), other.as<integer_object>()->value);
+        return value_eq_helper(value_to<integer_object>(), other.val<integer_object>());
     }
     return eq_helper(this, other);
 }
@@ -249,10 +249,10 @@ auto boolean_object::operator==(const object& other) const -> const object*
 auto boolean_object::operator>(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return value_gt_helper(as_value_of<integer_object, boolean_object>(), other.as<integer_object>()->value);
+        return value_gt_helper(value_to<integer_object>(), other.val<integer_object>());
     }
     if (other.is(decimal)) {
-        return value_gt_helper(as_value_of<decimal_object, boolean_object>(), other.as<decimal_object>()->value);
+        return value_gt_helper(value_to<decimal_object>(), other.val<decimal_object>());
     }
     return gt_helper(this, other);
 }
@@ -260,14 +260,14 @@ auto boolean_object::operator>(const object& other) const -> const object*
 auto boolean_object::operator+(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(as_value_of<integer_object, boolean_object>() + other.as<integer_object>()->value);
+        return make<integer_object>(value_to<integer_object>() + other.val<integer_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(as_value_of<decimal_object, boolean_object>() + other.as<decimal_object>()->value);
+        return make<decimal_object>(value_to<decimal_object>() + other.val<decimal_object>());
     }
     if (other.is(boolean)) {
-        return make<integer_object>(as_value_of<integer_object, boolean_object>()
-                                    + other.as_value_of<integer_object, boolean_object>());
+        return make<integer_object>(value_to<integer_object>()
+                                    + other.as<boolean_object>()->value_to<integer_object>());
     }
     return nullptr;
 }
@@ -275,14 +275,14 @@ auto boolean_object::operator+(const object& other) const -> const object*
 auto boolean_object::operator-(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(as_value_of<integer_object, boolean_object>() - other.as<integer_object>()->value);
+        return make<integer_object>(value_to<integer_object>() - other.val<integer_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(as_value_of<decimal_object, boolean_object>() - other.as<decimal_object>()->value);
+        return make<decimal_object>(value_to<decimal_object>() - other.val<decimal_object>());
     }
     if (other.is(boolean)) {
-        return make<integer_object>(as_value_of<integer_object, boolean_object>()
-                                    - other.as_value_of<integer_object, boolean_object>());
+        return make<integer_object>(value_to<integer_object>()
+                                    - other.as<boolean_object>()->value_to<integer_object>());
     }
     return nullptr;
 }
@@ -296,8 +296,8 @@ auto boolean_object::operator*(const object& other) const -> const object*
         return other * *this;
     }
     if (other.is(boolean)) {
-        return make<integer_object>(as_value_of<integer_object, boolean_object>()
-                                    - other.as_value_of<integer_object, boolean_object>());
+        return make<integer_object>(value_to<integer_object>()
+                                    - other.as<boolean_object>()->value_to<integer_object>());
     }
     return nullptr;
 }
@@ -305,23 +305,23 @@ auto boolean_object::operator*(const object& other) const -> const object*
 auto boolean_object::operator/(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        const auto other_value = other.as<integer_object>()->value;
+        const auto other_value = other.val<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<decimal_object>(as_value_of<decimal_object, boolean_object>()
-                                    / other.as_value_of<decimal_object, integer_object>());
+        return make<decimal_object>(value_to<decimal_object>()
+                                    / other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(boolean)) {
-        const auto other_value = other.as_value_of<integer_object, boolean_object>();
+        const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<decimal_object>(as_value_of<decimal_object, boolean_object>()
-                                    / other.as_value_of<decimal_object, boolean_object>());
+        return make<decimal_object>(value_to<decimal_object>()
+                                    / other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(as_value_of<decimal_object, integer_object>() / other.as<decimal_object>()->value);
+        return make<decimal_object>(value_to<decimal_object>() / other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -329,22 +329,21 @@ auto boolean_object::operator/(const object& other) const -> const object*
 auto boolean_object::operator%(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        const auto other_value = other.as<integer_object>()->value;
+        const auto other_value = other.val<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<integer_object>(math_mod(as_value_of<integer_object, boolean_object>(), other_value));
+        return make<integer_object>(math_mod(value_to<integer_object>(), other_value));
     }
     if (other.is(boolean)) {
-        const auto other_value = other.as_value_of<integer_object, boolean_object>();
+        const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<integer_object>(math_mod(as_value_of<integer_object, boolean_object>(), other_value));
+        return make<integer_object>(math_mod(value_to<integer_object>(), other_value));
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(
-            math_mod(as_value_of<decimal_object, boolean_object>(), other.as<decimal_object>()->value));
+        return make<decimal_object>(math_mod(value_to<decimal_object>(), other.val<decimal_object>()));
     }
     return nullptr;
 }
@@ -392,7 +391,7 @@ auto boolean_object::operator<<(const object& other) const -> const object*
                                     << static_cast<uint8_t>(other.as<boolean_object>()->value));
     }
     if (other.is(integer)) {
-        return make<integer_object>(as_value_of<integer_object, boolean_object>() << other.as<integer_object>()->value);
+        return make<integer_object>(value_to<integer_object>() << other.val<integer_object>());
     }
     return nullptr;
 }
@@ -404,7 +403,7 @@ auto boolean_object::operator>>(const object& other) const -> const object*
                                     >> static_cast<uint8_t>(other.as<boolean_object>()->value));
     }
     if (other.is(integer)) {
-        return make<integer_object>(as_value_of<integer_object, boolean_object>() >> other.as<integer_object>()->value);
+        return make<integer_object>(value_to<integer_object>() >> other.val<integer_object>());
     }
     return nullptr;
 }
@@ -417,10 +416,10 @@ auto integer_object::hash_key() const -> key_type
 auto integer_object::operator==(const object& other) const -> const object*
 {
     if (other.is(decimal)) {
-        return value_eq_helper(as_value_of<decimal_object, integer_object>(), other.as<decimal_object>()->value);
+        return value_eq_helper(value_to<decimal_object>(), other.val<decimal_object>());
     }
     if (other.is(boolean)) {
-        return value_eq_helper(value, other.as_value_of<integer_object, boolean_object>());
+        return value_eq_helper(value, other.as<boolean_object>()->value_to<integer_object>());
     }
     return eq_helper(this, other);
 }
@@ -428,10 +427,10 @@ auto integer_object::operator==(const object& other) const -> const object*
 auto integer_object::operator>(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return value_gt_helper(as_value_of<decimal_object, integer_object>(), other.as<decimal_object>()->value);
+        return value_gt_helper(value_to<integer_object>(), other.as<boolean_object>()->value_to<integer_object>());
     }
     if (other.is(decimal)) {
-        return value_gt_helper(as_value_of<decimal_object, integer_object>(), other.as<decimal_object>()->value);
+        return value_gt_helper(value_to<decimal_object>(), other.val<decimal_object>());
     }
     return gt_helper(this, other);
 }
@@ -439,13 +438,13 @@ auto integer_object::operator>(const object& other) const -> const object*
 auto integer_object::operator+(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value + other.as<integer_object>()->value);
+        return make<integer_object>(value + other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        return make<integer_object>(value + other.as_value_of<integer_object, boolean_object>());
+        return make<integer_object>(value + other.as<boolean_object>()->value_to<integer_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(other.as<decimal_object>()->value + as_value_of<decimal_object, integer_object>());
+        return make<decimal_object>(other.val<decimal_object>() + value_to<decimal_object>());
     }
     return nullptr;
 }
@@ -453,13 +452,13 @@ auto integer_object::operator+(const object& other) const -> const object*
 auto integer_object::operator-(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value - other.as<integer_object>()->value);
+        return make<integer_object>(value - other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        return make<integer_object>(value - other.as_value_of<integer_object, boolean_object>());
+        return make<integer_object>(value - other.as<boolean_object>()->value_to<integer_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(as_value_of<decimal_object, integer_object>() - other.as<decimal_object>()->value);
+        return make<decimal_object>(value_to<decimal_object>() - other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -467,13 +466,13 @@ auto integer_object::operator-(const object& other) const -> const object*
 auto integer_object::operator*(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value * other.as<integer_object>()->value);
+        return make<integer_object>(value * other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        return make<integer_object>(value * other.as_value_of<integer_object, boolean_object>());
+        return make<integer_object>(value * other.as<boolean_object>()->value_to<integer_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(as_value_of<decimal_object, integer_object>() * other.as<decimal_object>()->value);
+        return make<decimal_object>(value_to<decimal_object>() * other.val<decimal_object>());
     }
     if (other.is(array)) {
         return multiply_sequence_helper(other.as<array_object>(), value);
@@ -488,23 +487,23 @@ auto integer_object::operator*(const object& other) const -> const object*
 auto integer_object::operator/(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        const auto other_value = other.as<integer_object>()->value;
+        const auto other_value = other.val<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<decimal_object>(as_value_of<decimal_object, integer_object>()
-                                    / other.as_value_of<decimal_object, integer_object>());
+        return make<decimal_object>(value_to<decimal_object>()
+                                    / other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(boolean)) {
-        const auto other_value = other.as_value_of<integer_object, boolean_object>();
+        const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<decimal_object>(as_value_of<decimal_object, integer_object>()
-                                    / other.as_value_of<decimal_object, boolean_object>());
+        return make<decimal_object>(value_to<decimal_object>()
+                                    / other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(as_value_of<decimal_object, integer_object>() / other.as<decimal_object>()->value);
+        return make<decimal_object>(value_to<decimal_object>() / other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -512,22 +511,21 @@ auto integer_object::operator/(const object& other) const -> const object*
 auto integer_object::operator%(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        const auto other_value = other.as<integer_object>()->value;
+        const auto other_value = other.val<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
         return make<integer_object>(math_mod(value, other_value));
     }
     if (other.is(boolean)) {
-        const auto other_value = other.as_value_of<integer_object, boolean_object>();
+        const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
         return make<integer_object>(math_mod(value, other_value));
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(
-            math_mod(as_value_of<decimal_object, integer_object>(), other.as<decimal_object>()->value));
+        return make<decimal_object>(math_mod(value_to<decimal_object>(), other.val<decimal_object>()));
     }
     return nullptr;
 }
@@ -535,10 +533,10 @@ auto integer_object::operator%(const object& other) const -> const object*
 auto integer_object::operator|(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value | other.as<integer_object>()->value);
+        return make<integer_object>(value | other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        const auto other_value = other.as_value_of<integer_object, boolean_object>();
+        const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         return make<integer_object>(value | other_value);
     }
     return nullptr;
@@ -547,10 +545,10 @@ auto integer_object::operator|(const object& other) const -> const object*
 auto integer_object::operator^(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value ^ other.as<integer_object>()->value);
+        return make<integer_object>(value ^ other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        const auto other_value = other.as_value_of<integer_object, boolean_object>();
+        const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         return make<integer_object>(value ^ other_value);
     }
     return nullptr;
@@ -559,10 +557,10 @@ auto integer_object::operator^(const object& other) const -> const object*
 auto integer_object::operator<<(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value << other.as<integer_object>()->value);
+        return make<integer_object>(value << other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        const auto other_value = other.as_value_of<integer_object, boolean_object>();
+        const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         return make<integer_object>(value << other_value);
     }
     return nullptr;
@@ -571,10 +569,10 @@ auto integer_object::operator<<(const object& other) const -> const object*
 auto integer_object::operator>>(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value >> other.as<integer_object>()->value);
+        return make<integer_object>(value >> other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        const auto other_value = other.as_value_of<integer_object, boolean_object>();
+        const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         return make<integer_object>(value >> other_value);
     }
     return nullptr;
@@ -583,10 +581,10 @@ auto integer_object::operator>>(const object& other) const -> const object*
 auto integer_object::operator&(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value & other.as<integer_object>()->value);
+        return make<integer_object>(value & other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        const auto other_value = other.as_value_of<integer_object, boolean_object>();
+        const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         return make<integer_object>(value & other_value);
     }
     return nullptr;
@@ -595,10 +593,10 @@ auto integer_object::operator&(const object& other) const -> const object*
 auto decimal_object::operator==(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return value_eq_helper(value, other.as_value_of<decimal_object, boolean_object>());
+        return value_eq_helper(value, other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(integer)) {
-        return value_eq_helper(value, other.as_value_of<decimal_object, integer_object>());
+        return value_eq_helper(value, other.as<integer_object>()->value_to<decimal_object>());
     }
     return eq_helper(this, other);
 }
@@ -606,13 +604,13 @@ auto decimal_object::operator==(const object& other) const -> const object*
 auto decimal_object::operator+(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<decimal_object>(value + other.as_value_of<decimal_object, boolean_object>());
+        return make<decimal_object>(value + other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(integer)) {
-        return make<decimal_object>(value + other.as_value_of<decimal_object, integer_object>());
+        return make<decimal_object>(value + other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value + other.as<decimal_object>()->value);
+        return make<decimal_object>(value + other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -620,13 +618,13 @@ auto decimal_object::operator+(const object& other) const -> const object*
 auto decimal_object::operator-(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<decimal_object>(value - other.as_value_of<decimal_object, boolean_object>());
+        return make<decimal_object>(value - other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(integer)) {
-        return make<decimal_object>(value - other.as_value_of<decimal_object, integer_object>());
+        return make<decimal_object>(value - other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value - other.as<decimal_object>()->value);
+        return make<decimal_object>(value - other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -634,13 +632,13 @@ auto decimal_object::operator-(const object& other) const -> const object*
 auto decimal_object::operator*(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<decimal_object>(value * other.as_value_of<decimal_object, boolean_object>());
+        return make<decimal_object>(value * other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(integer)) {
-        return make<decimal_object>(value * other.as_value_of<decimal_object, integer_object>());
+        return make<decimal_object>(value * other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value * other.as<decimal_object>()->value);
+        return make<decimal_object>(value * other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -648,13 +646,13 @@ auto decimal_object::operator*(const object& other) const -> const object*
 auto decimal_object::operator/(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<decimal_object>(value / other.as_value_of<decimal_object, boolean_object>());
+        return make<decimal_object>(value / other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(integer)) {
-        return make<decimal_object>(value / other.as_value_of<decimal_object, integer_object>());
+        return make<decimal_object>(value / other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value / other.as<decimal_object>()->value);
+        return make<decimal_object>(value / other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -662,13 +660,13 @@ auto decimal_object::operator/(const object& other) const -> const object*
 auto decimal_object::operator%(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<decimal_object>(math_mod(value, other.as_value_of<decimal_object, boolean_object>()));
+        return make<decimal_object>(math_mod(value, other.as<boolean_object>()->value_to<decimal_object>()));
     }
     if (other.is(integer)) {
-        return make<decimal_object>(math_mod(value, other.as_value_of<decimal_object, integer_object>()));
+        return make<decimal_object>(math_mod(value, other.as<integer_object>()->value_to<decimal_object>()));
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(math_mod(value, other.as<decimal_object>()->value));
+        return make<decimal_object>(math_mod(value, other.val<decimal_object>()));
     }
     return nullptr;
 }
@@ -676,10 +674,10 @@ auto decimal_object::operator%(const object& other) const -> const object*
 auto decimal_object::operator>(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return value_gt_helper(value, other.as_value_of<decimal_object, boolean_object>());
+        return value_gt_helper(value, other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(integer)) {
-        return value_gt_helper(value, other.as_value_of<decimal_object, integer_object>());
+        return value_gt_helper(value, other.as<integer_object>()->value_to<decimal_object>());
     }
     return gt_helper(this, other);
 }
@@ -688,7 +686,7 @@ auto object_floor_div(const object* lhs, const object* rhs) -> const object*
 {
     const auto* div = (*lhs / *rhs);
     if (div->is(object::object_type::decimal)) {
-        return make<decimal_object>(std::floor(div->as<decimal_object>()->value));
+        return make<decimal_object>(std::floor(div->val<decimal_object>()));
     }
     return div;
 }
@@ -748,7 +746,7 @@ auto array_object::operator==(const object& other) const -> const object*
 auto array_object::operator*(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return multiply_sequence_helper(this, other.as<integer_object>()->value);
+        return multiply_sequence_helper(this, other.val<integer_object>());
     }
     return nullptr;
 }
@@ -972,14 +970,14 @@ auto check_nan(const object* expected) -> void
 {
     REQUIRE(expected != nullptr);
     REQUIRE(expected->is(decimal));
-    CHECK(std::isnan(expected->as<decimal_object>()->value));
+    CHECK(std::isnan(expected->val<decimal_object>()));
 }
 
 auto check_inf(const object* expected) -> void
 {
     REQUIRE(expected != nullptr);
     REQUIRE(expected->is(decimal));
-    CHECK(std::isinf(expected->as<decimal_object>()->value));
+    CHECK(std::isinf(expected->val<decimal_object>()));
 }
 
 auto check_div(const object& lhs, const object& rhs, const object& expected) -> void

--- a/source/object/object.hpp
+++ b/source/object/object.hpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <ios>
 #include <limits>
 #include <string>
 #include <unordered_map>
@@ -17,6 +18,7 @@
 #include <eval/environment.hpp>
 #include <fmt/ostream.h>
 #include <gc.hpp>
+#include <sys/types.h>
 
 struct object;
 auto tru() -> const object*;
@@ -74,7 +76,11 @@ struct object
         return static_cast<const T*>(this);
     }
 
-    [[nodiscard]] virtual auto cast_to(object_type /*type*/) const -> const object* { return nullptr; }
+    template<typename To, typename From>
+    [[nodiscard]] auto as_value_of() const -> typename To::value_type
+    {
+        return static_cast<typename To::value_type>(as<From>()->value);
+    }
 
     [[nodiscard]] auto is_error() const -> bool { return type() == object_type::error; }
 
@@ -164,7 +170,6 @@ struct integer_object final
 
     [[nodiscard]] auto hash_key() const -> key_type final;
 
-    [[nodiscard]] auto cast_to(object_type type) const -> const object* final;
     [[nodiscard]] auto operator==(const object& other) const -> const object* final;
     [[nodiscard]] auto operator>(const object& other) const -> const object* final;
     [[nodiscard]] auto operator+(const object& other) const -> const object* final;
@@ -172,6 +177,7 @@ struct integer_object final
     [[nodiscard]] auto operator*(const object& other) const -> const object* final;
     [[nodiscard]] auto operator/(const object& other) const -> const object* final;
     [[nodiscard]] auto operator%(const object& other) const -> const object* final;
+    // TODO: use unsigned for all the bit ops
     [[nodiscard]] auto operator&(const object& other) const -> const object* final;
     [[nodiscard]] auto operator|(const object& other) const -> const object* final;
     [[nodiscard]] auto operator^(const object& other) const -> const object* final;
@@ -197,8 +203,6 @@ struct decimal_object final : object
     [[nodiscard]] auto type() const -> object_type final { return object_type::decimal; }
 
     [[nodiscard]] auto inspect() const -> std::string final { return decimal_to_string(value); }
-
-    [[nodiscard]] auto cast_to(object_type type) const -> const object* final;
 
     [[nodiscard]] auto operator==(const object& other) const -> const object* final;
     [[nodiscard]] auto operator>(const object& other) const -> const object* final;
@@ -231,7 +235,6 @@ struct boolean_object final
     [[nodiscard]] auto is_hashable() const -> bool final { return true; }
 
     [[nodiscard]] auto hash_key() const -> key_type final;
-    [[nodiscard]] auto cast_to(object_type type) const -> const object* final;
     [[nodiscard]] auto operator==(const object& other) const -> const object* final;
     [[nodiscard]] auto operator+(const object& other) const -> const object* final;
     [[nodiscard]] auto operator-(const object& other) const -> const object* final;

--- a/source/object/object.hpp
+++ b/source/object/object.hpp
@@ -76,10 +76,10 @@ struct object
         return static_cast<const T*>(this);
     }
 
-    template<typename To, typename From>
-    [[nodiscard]] auto as_value_of() const -> typename To::value_type
+    template<typename T>
+    [[nodiscard]] auto val() const -> typename T::value_type
     {
-        return static_cast<typename To::value_type>(as<From>()->value);
+        return as<T>()->value;
     }
 
     [[nodiscard]] auto is_error() const -> bool { return type() == object_type::error; }
@@ -160,6 +160,12 @@ struct integer_object final
     {
     }
 
+    template<typename T>
+    [[nodiscard]] auto value_to() const -> typename T::value_type
+    {
+        return static_cast<typename T::value_type>(val<integer_object>());
+    }
+
     [[nodiscard]] auto is_truthy() const -> bool final { return value != 0; }
 
     [[nodiscard]] auto type() const -> object_type final { return object_type::integer; }
@@ -198,6 +204,12 @@ struct decimal_object final : object
     {
     }
 
+    template<typename T>
+    [[nodiscard]] auto value_to() const -> typename T::value_type
+    {
+        return static_cast<typename T::value_type>(val<decimal_object>());
+    }
+
     [[nodiscard]] auto is_truthy() const -> bool final { return value != 0.0; }
 
     [[nodiscard]] auto type() const -> object_type final { return object_type::decimal; }
@@ -224,6 +236,12 @@ struct boolean_object final
     explicit boolean_object(value_type val)
         : value {val}
     {
+    }
+
+    template<typename T>
+    [[nodiscard]] auto value_to() const -> typename T::value_type
+    {
+        return static_cast<typename T::value_type>(val<boolean_object>());
     }
 
     [[nodiscard]] auto is_truthy() const -> bool final { return value; }

--- a/source/vm/vm.hpp
+++ b/source/vm/vm.hpp
@@ -9,7 +9,7 @@
 #include <gc.hpp>
 #include <object/object.hpp>
 
-constexpr size_t stack_size = 2048UL;
+constexpr size_t stack_size = 2 * 2048UL;
 constexpr size_t globals_size = 65536UL;
 constexpr size_t max_frames = 1024UL;
 


### PR DESCRIPTION
also preallocate 64M objects