### PR TITLE
chore: rename make to allocate

### DIFF
--- a/source/builtin/builtin.cpp
+++ b/source/builtin/builtin.cpp
@@ -38,17 +38,17 @@ const builtin len {
         using enum object::object_type;
         if (maybe_string_or_array_or_hash->is(string)) {
             const auto& str = maybe_string_or_array_or_hash->as<string_object>()->value;
-            return make<integer_object>(static_cast<int64_t>(str.size()));
+            return allocate<integer_object>(static_cast<int64_t>(str.size()));
         }
         if (maybe_string_or_array_or_hash->is(array)) {
             const auto& arr = maybe_string_or_array_or_hash->as<array_object>()->value;
 
-            return make<integer_object>(static_cast<int64_t>(arr.size()));
+            return allocate<integer_object>(static_cast<int64_t>(arr.size()));
         }
         if (maybe_string_or_array_or_hash->is(hash)) {
             const auto& hsh = maybe_string_or_array_or_hash->as<hash_object>()->value;
 
-            return make<integer_object>(static_cast<int64_t>(hsh.size()));
+            return allocate<integer_object>(static_cast<int64_t>(hsh.size()));
         }
         return make_error("argument of type {} to len() is not supported", maybe_string_or_array_or_hash->type());
     }};
@@ -86,7 +86,7 @@ const builtin first {
         if (maybe_string_or_array->is(string)) {
             const auto& str = maybe_string_or_array->as<string_object>()->value;
             if (!str.empty()) {
-                return make<string_object>(str.substr(0, 1));
+                return allocate<string_object>(str.substr(0, 1));
             }
             return null();
         }
@@ -113,7 +113,7 @@ const builtin last {
         if (maybe_string_or_array->is(string)) {
             const auto& str = maybe_string_or_array->as<string_object>()->value;
             if (!str.empty()) {
-                return make<string_object>(str.substr(str.length() - 1, 1));
+                return allocate<string_object>(str.substr(str.length() - 1, 1));
             }
             return null();
         }
@@ -140,7 +140,7 @@ const builtin rest {
         if (maybe_string_or_array->is(string)) {
             const auto& str = maybe_string_or_array->as<string_object>()->value;
             if (str.size() > 1) {
-                return make<string_object>(str.substr(1));
+                return allocate<string_object>(str.substr(1));
             }
             return null();
         }
@@ -149,7 +149,7 @@ const builtin rest {
             if (arr.size() > 1) {
                 array_object::value_type rest;
                 std::copy(arr.cbegin() + 1, arr.cend(), std::back_inserter(rest));
-                return make<array_object>(std::move(rest));
+                return allocate<array_object>(std::move(rest));
             }
             return null();
         }
@@ -171,12 +171,12 @@ const builtin push {
             if (lhs->is(array)) {
                 auto copy = lhs->as<array_object>()->value;
                 copy.push_back(rhs);
-                return make<array_object>(std::move(copy));
+                return allocate<array_object>(std::move(copy));
             }
             if (lhs->is(string) && rhs->is(string)) {
                 auto copy = lhs->as<string_object>()->value;
                 copy.append(rhs->as<string_object>()->value);
-                return make<string_object>(std::move(copy));
+                return allocate<string_object>(std::move(copy));
             }
             return make_error("argument of type {} and {} to push() are not supported", lhs->type(), rhs->type());
         }
@@ -190,7 +190,7 @@ const builtin push {
                 }
                 auto copy = lhs->as<hash_object>()->value;
                 copy.insert_or_assign(k->as<hashable>()->hash_key(), v);
-                return make<hash_object>(std::move(copy));
+                return allocate<hash_object>(std::move(copy));
             }
             return make_error(
                 "argument of type {}, {} and {} to push() are not supported", lhs->type(), k->type(), v->type());
@@ -207,7 +207,7 @@ const builtin type {"type",
                                               arguments.size());
                         }
                         const auto& val = arguments[0];
-                        return make<string_object>(fmt::format("{}", val->type()));
+                        return allocate<string_object>(fmt::format("{}", val->type()));
                     }};
 const builtin chr {"chr",
                    {"int"},
@@ -221,7 +221,7 @@ const builtin chr {"chr",
                        if (val->is(object::object_type::integer)) {
                            const auto& as_int = val->as<integer_object>()->value;
                            if (isascii(static_cast<int>(as_int))) {
-                               return make<string_object>(fmt::format("{}", static_cast<char>(as_int)));
+                               return allocate<string_object>(fmt::format("{}", static_cast<char>(as_int)));
                            }
                            return make_error("number {} is out of range to be an ascii character", as_int);
                        }

--- a/source/compiler/compiler.cpp
+++ b/source/compiler/compiler.cpp
@@ -48,7 +48,7 @@ auto compiler::create() -> compiler
     for (auto idx = 0; const auto& builtin : builtin::builtins()) {
         symbols->define_builtin(idx++, builtin->name);
     }
-    return {make<constants>(), symbols};
+    return {allocate<constants>(), symbols};
 }
 
 compiler::compiler(constants* consts, symbol_table* symbols)
@@ -389,7 +389,7 @@ void compiler::visit(const while_statement& expr)
     for (const auto& sym : free) {
         load_symbol(sym);
     }
-    auto* cmpl = make<compiled_function_object>(std::move(instrs), num_locals, 0);
+    auto* cmpl = allocate<compiled_function_object>(std::move(instrs), num_locals, 0);
     cmpl->inside_loop = true;
     auto function_index = add_constant(cmpl);
     emit(closure, {function_index, free.size()});
@@ -415,12 +415,12 @@ void compiler::visit(const index_expression& expr)
 
 void compiler::visit(const integer_literal& expr)
 {
-    emit(opcodes::constant, add_constant(make<integer_object>(expr.value)));
+    emit(opcodes::constant, add_constant(allocate<integer_object>(expr.value)));
 }
 
 void compiler::visit(const decimal_literal& expr)
 {
-    emit(opcodes::constant, add_constant(make<decimal_object>(expr.value)));
+    emit(opcodes::constant, add_constant(allocate<decimal_object>(expr.value)));
 }
 
 void compiler::visit(const program& expr)
@@ -477,7 +477,7 @@ void compiler::visit(const block_statement& expr)
 
 void compiler::visit(const string_literal& expr)
 {
-    emit(opcodes::constant, add_constant(make<string_object>(expr.value)));
+    emit(opcodes::constant, add_constant(allocate<string_object>(expr.value)));
 }
 
 void compiler::visit(const unary_expression& expr)
@@ -520,7 +520,7 @@ void compiler::visit(const function_literal& expr)
         load_symbol(sym);
     }
     auto function_index = add_constant(
-        make<compiled_function_object>(std::move(instrs), num_locals, static_cast<int>(expr.parameters.size())));
+        allocate<compiled_function_object>(std::move(instrs), num_locals, static_cast<int>(expr.parameters.size())));
     emit(closure, {function_index, free.size()});
 }
 

--- a/source/compiler/symbol_table.cpp
+++ b/source/compiler/symbol_table.cpp
@@ -56,12 +56,12 @@ auto operator<<(std::ostream& ost, const symbol_pointer& ptr) -> std::ostream&
 
 auto symbol_table::create() -> symbol_table*
 {
-    return make<symbol_table>();
+    return allocate<symbol_table>();
 }
 
 auto symbol_table::create_enclosed(symbol_table* outer, bool inside_loop) -> symbol_table*
 {
-    return make<symbol_table>(outer, inside_loop);
+    return allocate<symbol_table>(outer, inside_loop);
 }
 
 symbol_table::symbol_table(symbol_table* outer, bool inside_loop)

--- a/source/gc.hpp
+++ b/source/gc.hpp
@@ -43,7 +43,7 @@ class gc
 
 template<typename T, typename... Args>
     requires std::derived_from<T, struct object>
-auto make(Args&&... args) -> T*
+auto allocate(Args&&... args) -> T*
 {
     T* p = new T(std::forward<Args>(args)...);
     gc<object>::track(p);
@@ -52,7 +52,7 @@ auto make(Args&&... args) -> T*
 
 template<typename T, typename... Args>
     requires std::derived_from<T, struct expression>
-auto make(Args&&... args) -> T*
+auto allocate(Args&&... args) -> T*
 {
     T* p = new T(std::forward<Args>(args)...);
     gc<expression>::track(p);
@@ -60,7 +60,7 @@ auto make(Args&&... args) -> T*
 }
 
 template<typename T, typename... Args>
-auto make(Args&&... args) -> T*
+auto allocate(Args&&... args) -> T*
 {
     T* p = new T(std::forward<Args>(args)...);
     gc<T>::track(p);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -208,9 +208,9 @@ auto run_file(const command_line_args& opts) -> int
             std::cout << result->inspect() << '\n';
         }
     } else {
-        auto* global_env = make<environment>();
+        auto* global_env = allocate<environment>();
         for (const auto& builtin : builtin::builtins()) {
-            global_env->set(builtin->name, make<builtin_object>(builtin));
+            global_env->set(builtin->name, allocate<builtin_object>(builtin));
         }
         evaluator ev {global_env};
         const auto* result = ev.evaluate(prgrm);
@@ -229,13 +229,13 @@ auto run_repl(const command_line_args& opts) -> int
     std::cout << "Cappuchin programming language using engine: " << opts.mode << ".\n";
     std::cout << get_build_type() << " built with " << get_compiler_identifier() << '\n';
     std::cout << "Feel free to type in commands\n";
-    auto* global_env = opts.mode == engine::eval ? make<environment>() : nullptr;
+    auto* global_env = opts.mode == engine::eval ? allocate<environment>() : nullptr;
     auto* symbols = opts.mode == engine::vm ? symbol_table::create() : nullptr;
     constants consts;
     constants globals(globals_size);
     for (auto idx = 0; const auto& builtin : builtin::builtins()) {
         if (global_env != nullptr) {
-            global_env->set(builtin->name, make<builtin_object>(builtin));
+            global_env->set(builtin->name, allocate<builtin_object>(builtin));
         }
         if (symbols != nullptr) {
             symbols->define_builtin(idx, builtin->name);

--- a/source/object/object.cpp
+++ b/source/object/object.cpp
@@ -103,7 +103,7 @@ auto multiply_sequence_helper(const T* source, integer_object::value_type count)
     for (integer_object::value_type i = 0; i < count; i++) {
         std::copy(source->value.cbegin(), source->value.cend(), std::back_inserter(target));
     }
-    return make<T>(std::move(target));
+    return allocate<T>(std::move(target));
 }
 
 auto math_mod(integer_object::value_type lhs, integer_object::value_type rhs) -> integer_object::value_type
@@ -231,7 +231,7 @@ auto string_object::operator>=(const object& other) const -> const object*
 auto string_object::operator+(const object& other) const -> const object*
 {
     if (other.is(string)) {
-        return make<string_object>(value + other.val<string_object>());
+        return allocate<string_object>(value + other.val<string_object>());
     }
     return nullptr;
 }
@@ -291,8 +291,8 @@ auto boolean_object::operator+(const object& other) const -> const object*
         return other + *this;
     }
     if (other.is(boolean)) {
-        return make<integer_object>(value_to<integer_object>()
-                                    + other.as<boolean_object>()->value_to<integer_object>());
+        return allocate<integer_object>(value_to<integer_object>()
+                                        + other.as<boolean_object>()->value_to<integer_object>());
     }
     return nullptr;
 }
@@ -300,14 +300,14 @@ auto boolean_object::operator+(const object& other) const -> const object*
 auto boolean_object::operator-(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value_to<integer_object>() - other.val<integer_object>());
+        return allocate<integer_object>(value_to<integer_object>() - other.val<integer_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value_to<decimal_object>() - other.val<decimal_object>());
+        return allocate<decimal_object>(value_to<decimal_object>() - other.val<decimal_object>());
     }
     if (other.is(boolean)) {
-        return make<integer_object>(value_to<integer_object>()
-                                    - other.as<boolean_object>()->value_to<integer_object>());
+        return allocate<integer_object>(value_to<integer_object>()
+                                        - other.as<boolean_object>()->value_to<integer_object>());
     }
     return nullptr;
 }
@@ -321,8 +321,8 @@ auto boolean_object::operator*(const object& other) const -> const object*
         return other * *this;
     }
     if (other.is(boolean)) {
-        return make<integer_object>(value_to<integer_object>()
-                                    - other.as<boolean_object>()->value_to<integer_object>());
+        return allocate<integer_object>(value_to<integer_object>()
+                                        - other.as<boolean_object>()->value_to<integer_object>());
     }
     return nullptr;
 }
@@ -334,19 +334,19 @@ auto boolean_object::operator/(const object& other) const -> const object*
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<decimal_object>(value_to<decimal_object>()
-                                    / other.as<integer_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value_to<decimal_object>()
+                                        / other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(boolean)) {
         const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<decimal_object>(value_to<decimal_object>()
-                                    / other.as<boolean_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value_to<decimal_object>()
+                                        / other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value_to<decimal_object>() / other.val<decimal_object>());
+        return allocate<decimal_object>(value_to<decimal_object>() / other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -358,17 +358,17 @@ auto boolean_object::operator%(const object& other) const -> const object*
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<integer_object>(math_mod(value_to<integer_object>(), other_value));
+        return allocate<integer_object>(math_mod(value_to<integer_object>(), other_value));
     }
     if (other.is(boolean)) {
         const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<integer_object>(math_mod(value_to<integer_object>(), other_value));
+        return allocate<integer_object>(math_mod(value_to<integer_object>(), other_value));
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(math_mod(value_to<decimal_object>(), other.val<decimal_object>()));
+        return allocate<decimal_object>(math_mod(value_to<decimal_object>(), other.val<decimal_object>()));
     }
     return nullptr;
 }
@@ -376,7 +376,7 @@ auto boolean_object::operator%(const object& other) const -> const object*
 auto boolean_object::operator&(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<boolean_object>(value & other.val<boolean_object>());
+        return allocate<boolean_object>(value & other.val<boolean_object>());
     }
     if (other.is(integer)) {
         return other & *this;
@@ -387,7 +387,7 @@ auto boolean_object::operator&(const object& other) const -> const object*
 auto boolean_object::operator|(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<boolean_object>(value | other.val<boolean_object>());
+        return allocate<boolean_object>(value | other.val<boolean_object>());
     }
     if (other.is(integer)) {
         return other | *this;
@@ -398,7 +398,7 @@ auto boolean_object::operator|(const object& other) const -> const object*
 auto boolean_object::operator^(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<boolean_object>(value ^ other.val<boolean_object>());
+        return allocate<boolean_object>(value ^ other.val<boolean_object>());
     }
     if (other.is(integer)) {
         return other ^ *this;
@@ -409,10 +409,10 @@ auto boolean_object::operator^(const object& other) const -> const object*
 auto boolean_object::operator<<(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<integer_object>(value_to<integer_object>() << other.val<boolean_object>());
+        return allocate<integer_object>(value_to<integer_object>() << other.val<boolean_object>());
     }
     if (other.is(integer)) {
-        return make<integer_object>(value_to<integer_object>() << other.val<integer_object>());
+        return allocate<integer_object>(value_to<integer_object>() << other.val<integer_object>());
     }
     return nullptr;
 }
@@ -420,10 +420,10 @@ auto boolean_object::operator<<(const object& other) const -> const object*
 auto boolean_object::operator>>(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<integer_object>(value_to<integer_object>() >> other.val<boolean_object>());
+        return allocate<integer_object>(value_to<integer_object>() >> other.val<boolean_object>());
     }
     if (other.is(integer)) {
-        return make<integer_object>(value_to<integer_object>() >> other.val<integer_object>());
+        return allocate<integer_object>(value_to<integer_object>() >> other.val<integer_object>());
     }
     return nullptr;
 }
@@ -469,13 +469,13 @@ auto integer_object::operator>=(const object& other) const -> const object*
 auto integer_object::operator+(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value + other.val<integer_object>());
+        return allocate<integer_object>(value + other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        return make<integer_object>(value + other.as<boolean_object>()->value_to<integer_object>());
+        return allocate<integer_object>(value + other.as<boolean_object>()->value_to<integer_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(other.val<decimal_object>() + value_to<decimal_object>());
+        return allocate<decimal_object>(other.val<decimal_object>() + value_to<decimal_object>());
     }
     return nullptr;
 }
@@ -483,13 +483,13 @@ auto integer_object::operator+(const object& other) const -> const object*
 auto integer_object::operator-(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value - other.val<integer_object>());
+        return allocate<integer_object>(value - other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        return make<integer_object>(value - other.as<boolean_object>()->value_to<integer_object>());
+        return allocate<integer_object>(value - other.as<boolean_object>()->value_to<integer_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value_to<decimal_object>() - other.val<decimal_object>());
+        return allocate<decimal_object>(value_to<decimal_object>() - other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -497,13 +497,13 @@ auto integer_object::operator-(const object& other) const -> const object*
 auto integer_object::operator*(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value * other.val<integer_object>());
+        return allocate<integer_object>(value * other.val<integer_object>());
     }
     if (other.is(boolean)) {
-        return make<integer_object>(value * other.as<boolean_object>()->value_to<integer_object>());
+        return allocate<integer_object>(value * other.as<boolean_object>()->value_to<integer_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value_to<decimal_object>() * other.val<decimal_object>());
+        return allocate<decimal_object>(value_to<decimal_object>() * other.val<decimal_object>());
     }
     if (other.is(array)) {
         return multiply_sequence_helper(other.as<array_object>(), value);
@@ -522,19 +522,19 @@ auto integer_object::operator/(const object& other) const -> const object*
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<decimal_object>(value_to<decimal_object>()
-                                    / other.as<integer_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value_to<decimal_object>()
+                                        / other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(boolean)) {
         const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<decimal_object>(value_to<decimal_object>()
-                                    / other.as<boolean_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value_to<decimal_object>()
+                                        / other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value_to<decimal_object>() / other.val<decimal_object>());
+        return allocate<decimal_object>(value_to<decimal_object>() / other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -546,17 +546,17 @@ auto integer_object::operator%(const object& other) const -> const object*
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<integer_object>(math_mod(value, other_value));
+        return allocate<integer_object>(math_mod(value, other_value));
     }
     if (other.is(boolean)) {
         const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
         if (other_value == 0) {
             return make_error("division by zero");
         }
-        return make<integer_object>(math_mod(value, other_value));
+        return allocate<integer_object>(math_mod(value, other_value));
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(math_mod(value_to<decimal_object>(), other.val<decimal_object>()));
+        return allocate<decimal_object>(math_mod(value_to<decimal_object>(), other.val<decimal_object>()));
     }
     return nullptr;
 }
@@ -564,11 +564,11 @@ auto integer_object::operator%(const object& other) const -> const object*
 auto integer_object::operator|(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value | other.val<integer_object>());
+        return allocate<integer_object>(value | other.val<integer_object>());
     }
     if (other.is(boolean)) {
         const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
-        return make<integer_object>(value | other_value);
+        return allocate<integer_object>(value | other_value);
     }
     return nullptr;
 }
@@ -576,11 +576,11 @@ auto integer_object::operator|(const object& other) const -> const object*
 auto integer_object::operator^(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value ^ other.val<integer_object>());
+        return allocate<integer_object>(value ^ other.val<integer_object>());
     }
     if (other.is(boolean)) {
         const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
-        return make<integer_object>(value ^ other_value);
+        return allocate<integer_object>(value ^ other_value);
     }
     return nullptr;
 }
@@ -588,11 +588,11 @@ auto integer_object::operator^(const object& other) const -> const object*
 auto integer_object::operator<<(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value << other.val<integer_object>());
+        return allocate<integer_object>(value << other.val<integer_object>());
     }
     if (other.is(boolean)) {
         const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
-        return make<integer_object>(value << other_value);
+        return allocate<integer_object>(value << other_value);
     }
     return nullptr;
 }
@@ -600,11 +600,11 @@ auto integer_object::operator<<(const object& other) const -> const object*
 auto integer_object::operator>>(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value >> other.val<integer_object>());
+        return allocate<integer_object>(value >> other.val<integer_object>());
     }
     if (other.is(boolean)) {
         const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
-        return make<integer_object>(value >> other_value);
+        return allocate<integer_object>(value >> other_value);
     }
     return nullptr;
 }
@@ -612,11 +612,11 @@ auto integer_object::operator>>(const object& other) const -> const object*
 auto integer_object::operator&(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value & other.val<integer_object>());
+        return allocate<integer_object>(value & other.val<integer_object>());
     }
     if (other.is(boolean)) {
         const auto other_value = other.as<boolean_object>()->value_to<integer_object>();
-        return make<integer_object>(value & other_value);
+        return allocate<integer_object>(value & other_value);
     }
     return nullptr;
 }
@@ -635,13 +635,13 @@ auto decimal_object::operator==(const object& other) const -> const object*
 auto decimal_object::operator+(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<decimal_object>(value + other.as<boolean_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value + other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(integer)) {
-        return make<decimal_object>(value + other.as<integer_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value + other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value + other.val<decimal_object>());
+        return allocate<decimal_object>(value + other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -649,13 +649,13 @@ auto decimal_object::operator+(const object& other) const -> const object*
 auto decimal_object::operator-(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<decimal_object>(value - other.as<boolean_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value - other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(integer)) {
-        return make<decimal_object>(value - other.as<integer_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value - other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value - other.val<decimal_object>());
+        return allocate<decimal_object>(value - other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -663,13 +663,13 @@ auto decimal_object::operator-(const object& other) const -> const object*
 auto decimal_object::operator*(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<decimal_object>(value * other.as<boolean_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value * other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(integer)) {
-        return make<decimal_object>(value * other.as<integer_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value * other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value * other.val<decimal_object>());
+        return allocate<decimal_object>(value * other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -677,13 +677,13 @@ auto decimal_object::operator*(const object& other) const -> const object*
 auto decimal_object::operator/(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<decimal_object>(value / other.as<boolean_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value / other.as<boolean_object>()->value_to<decimal_object>());
     }
     if (other.is(integer)) {
-        return make<decimal_object>(value / other.as<integer_object>()->value_to<decimal_object>());
+        return allocate<decimal_object>(value / other.as<integer_object>()->value_to<decimal_object>());
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(value / other.val<decimal_object>());
+        return allocate<decimal_object>(value / other.val<decimal_object>());
     }
     return nullptr;
 }
@@ -691,13 +691,13 @@ auto decimal_object::operator/(const object& other) const -> const object*
 auto decimal_object::operator%(const object& other) const -> const object*
 {
     if (other.is(boolean)) {
-        return make<decimal_object>(math_mod(value, other.as<boolean_object>()->value_to<decimal_object>()));
+        return allocate<decimal_object>(math_mod(value, other.as<boolean_object>()->value_to<decimal_object>()));
     }
     if (other.is(integer)) {
-        return make<decimal_object>(math_mod(value, other.as<integer_object>()->value_to<decimal_object>()));
+        return allocate<decimal_object>(math_mod(value, other.as<integer_object>()->value_to<decimal_object>()));
     }
     if (other.is(decimal)) {
-        return make<decimal_object>(math_mod(value, other.val<decimal_object>()));
+        return allocate<decimal_object>(math_mod(value, other.val<decimal_object>()));
     }
     return nullptr;
 }
@@ -728,7 +728,7 @@ auto object_floor_div(const object* lhs, const object* rhs) -> const object*
 {
     const auto* div = (*lhs / *rhs);
     if (div->is(decimal)) {
-        return make<decimal_object>(std::floor(div->val<decimal_object>()));
+        return allocate<decimal_object>(std::floor(div->val<decimal_object>()));
     }
     return div;
 }
@@ -799,7 +799,7 @@ auto array_object::operator+(const object& other) const -> const object*
         value_type concat = value;
         const auto& other_value = other.as<array_object>()->value;
         std::copy(other_value.cbegin(), other_value.cend(), std::back_inserter(concat));
-        return make<array_object>(std::move(concat));
+        return allocate<array_object>(std::move(concat));
     }
     return nullptr;
 }
@@ -860,7 +860,7 @@ auto hash_object::operator+(const object& other) const -> const object*
         for (const auto& pair : other_value) {
             concat.insert_or_assign(pair.first, pair.second);
         }
-        return make<hash_object>(std::move(concat));
+        return allocate<hash_object>(std::move(concat));
     }
     return nullptr;
 }

--- a/source/object/object.hpp
+++ b/source/object/object.hpp
@@ -342,7 +342,7 @@ struct error_object final : object
 template<typename... T>
 auto make_error(fmt::format_string<T...> fmt, T&&... args) -> object*
 {
-    return make<error_object>(fmt::format(fmt, std::forward<T>(args)...));
+    return allocate<error_object>(fmt::format(fmt, std::forward<T>(args)...));
 }
 
 struct array_object final : object

--- a/source/parser/parser.cpp
+++ b/source/parser/parser.cpp
@@ -143,7 +143,7 @@ parser::parser(lexer lxr)
 
 auto parser::parse_program() -> program*
 {
-    auto* prog = make<program>(m_current_token.loc);
+    auto* prog = allocate<program>(m_current_token.loc);
     while (m_current_token.type != token_type::eof) {
         auto* stmt = parse_statement();
         if (stmt != nullptr) {
@@ -191,7 +191,7 @@ auto parser::parse_statement() -> statement*
 
 auto parser::parse_let_statement() -> statement*
 {
-    auto* stmt = make<let_statement>(m_current_token.loc);
+    auto* stmt = allocate<let_statement>(m_current_token.loc);
     stmt->l = m_current_token.loc;
     using enum token_type;
     if (!get(ident)) {
@@ -218,7 +218,7 @@ auto parser::parse_let_statement() -> statement*
 
 auto parser::parse_assign_statement() -> statement*
 {
-    auto* stmt = make<assign_expression>(m_current_token.loc);
+    auto* stmt = allocate<assign_expression>(m_current_token.loc);
     using enum token_type;
 
     stmt->name = parse_identifier();
@@ -239,7 +239,7 @@ auto parser::parse_assign_statement() -> statement*
 auto parser::parse_return_statement() -> statement*
 {
     using enum token_type;
-    auto* stmt = make<return_statement>(m_current_token.loc);
+    auto* stmt = allocate<return_statement>(m_current_token.loc);
 
     next_token();
     stmt->value = parse_expression(lowest);
@@ -252,7 +252,7 @@ auto parser::parse_return_statement() -> statement*
 
 auto parser::parse_expression_statement() -> statement*
 {
-    auto* expr_stmt = make<expression_statement>(m_current_token.loc);
+    auto* expr_stmt = allocate<expression_statement>(m_current_token.loc);
     expr_stmt->expr = parse_expression(lowest);
     if (peek_token_is(token_type::semicolon)) {
         next_token();
@@ -282,12 +282,12 @@ auto parser::parse_expression(int precedence) -> expression*
 
 auto parser::parse_identifier() const -> identifier*
 {
-    return make<identifier>(std::string(m_current_token.literal), m_current_token.loc);
+    return allocate<identifier>(std::string(m_current_token.literal), m_current_token.loc);
 }
 
 auto parser::parse_integer_literal() -> expression*
 {
-    auto* lit = make<integer_literal>(m_current_token.loc);
+    auto* lit = allocate<integer_literal>(m_current_token.loc);
     try {
         lit->value = std::stoll(std::string {m_current_token.literal});
     } catch (const std::out_of_range&) {
@@ -299,7 +299,7 @@ auto parser::parse_integer_literal() -> expression*
 
 auto parser::parse_decimal_literal() -> expression*
 {
-    auto* lit = make<decimal_literal>(m_current_token.loc);
+    auto* lit = allocate<decimal_literal>(m_current_token.loc);
     try {
         lit->value = std::stod(std::string {m_current_token.literal});
     } catch (const std::out_of_range&) {
@@ -311,7 +311,7 @@ auto parser::parse_decimal_literal() -> expression*
 
 auto parser::parse_unary_expression() -> expression*
 {
-    auto* unary = make<unary_expression>(m_current_token.loc);
+    auto* unary = allocate<unary_expression>(m_current_token.loc);
     unary->op = m_current_token.type;
 
     next_token();
@@ -321,7 +321,7 @@ auto parser::parse_unary_expression() -> expression*
 
 auto parser::parse_boolean() -> expression*
 {
-    return make<boolean_literal>(current_token_is(token_type::tru), m_current_token.loc);
+    return allocate<boolean_literal>(current_token_is(token_type::tru), m_current_token.loc);
 }
 
 auto parser::parse_grouped_expression() -> expression*
@@ -337,7 +337,7 @@ auto parser::parse_grouped_expression() -> expression*
 auto parser::parse_if_expression() -> expression*
 {
     using enum token_type;
-    auto* expr = make<if_expression>(m_current_token.loc);
+    auto* expr = allocate<if_expression>(m_current_token.loc);
     if (!get(lparen)) {
         return {};
     }
@@ -368,7 +368,7 @@ auto parser::parse_if_expression() -> expression*
 auto parser::parse_while_statement() -> expression*
 {
     using enum token_type;
-    auto* expr = make<while_statement>(m_current_token.loc);
+    auto* expr = allocate<while_statement>(m_current_token.loc);
     if (!get(lparen)) {
         return {};
     }
@@ -400,7 +400,7 @@ auto parser::parse_function_expression() -> expression*
         return {};
     }
     auto* body = parse_block_statement();
-    return make<function_literal>(std::move(parameters), body, loc);
+    return allocate<function_literal>(std::move(parameters), body, loc);
 }
 
 auto parser::parse_function_parameters() -> identifiers
@@ -429,7 +429,7 @@ auto parser::parse_function_parameters() -> identifiers
 auto parser::parse_block_statement() -> block_statement*
 {
     using enum token_type;
-    auto* block = make<block_statement>(m_current_token.loc);
+    auto* block = allocate<block_statement>(m_current_token.loc);
     next_token();
     while (!current_token_is(rsquirly) && !current_token_is(eof)) {
         auto* stmt = parse_statement();
@@ -445,7 +445,7 @@ auto parser::parse_block_statement() -> block_statement*
 auto parser::parse_break_statement() -> statement*
 {
     using enum token_type;
-    auto* b = make<break_statement>(m_current_token.loc);
+    auto* b = allocate<break_statement>(m_current_token.loc);
     if (peek_token_is(semicolon)) {
         next_token();
     }
@@ -455,7 +455,7 @@ auto parser::parse_break_statement() -> statement*
 auto parser::parse_continue_statement() -> statement*
 {
     using enum token_type;
-    auto* b = make<continue_statement>(m_current_token.loc);
+    auto* b = allocate<continue_statement>(m_current_token.loc);
     if (peek_token_is(semicolon)) {
         next_token();
     }
@@ -464,7 +464,7 @@ auto parser::parse_continue_statement() -> statement*
 
 auto parser::parse_call_expression(expression* function) -> expression*
 {
-    auto* call = make<call_expression>(m_current_token.loc);
+    auto* call = allocate<call_expression>(m_current_token.loc);
     call->function = function;
     call->arguments = parse_expressions(token_type::rparen);
     return call;
@@ -472,7 +472,7 @@ auto parser::parse_call_expression(expression* function) -> expression*
 
 auto parser::parse_binary_expression(expression* left) -> expression*
 {
-    auto* bin_expr = make<binary_expression>(m_current_token.loc);
+    auto* bin_expr = allocate<binary_expression>(m_current_token.loc);
     bin_expr->op = m_current_token.type;
     bin_expr->left = left;
 
@@ -485,7 +485,7 @@ auto parser::parse_binary_expression(expression* left) -> expression*
 
 auto parser::parse_string_literal() const -> expression*
 {
-    return make<string_literal>(std::string {m_current_token.literal}, m_current_token.loc);
+    return allocate<string_literal>(std::string {m_current_token.literal}, m_current_token.loc);
 }
 
 auto parser::parse_expressions(token_type end) -> expressions
@@ -514,14 +514,14 @@ auto parser::parse_expressions(token_type end) -> expressions
 
 auto parser::parse_array_expression() -> expression*
 {
-    auto* array_expr = make<array_literal>(m_current_token.loc);
+    auto* array_expr = allocate<array_literal>(m_current_token.loc);
     array_expr->elements = parse_expressions(token_type::rbracket);
     return array_expr;
 }
 
 auto parser::parse_index_expression(expression* left) -> expression*
 {
-    auto* index_expr = make<index_expression>(m_current_token.loc);
+    auto* index_expr = allocate<index_expression>(m_current_token.loc);
     index_expr->left = left;
     next_token();
     index_expr->index = parse_expression(lowest);
@@ -535,7 +535,7 @@ auto parser::parse_index_expression(expression* left) -> expression*
 
 auto parser::parse_hash_literal() -> expression*
 {
-    auto* hash = make<hash_literal>(m_current_token.loc);
+    auto* hash = allocate<hash_literal>(m_current_token.loc);
     using enum token_type;
     while (!peek_token_is(rsquirly)) {
         next_token();
@@ -559,7 +559,7 @@ auto parser::parse_hash_literal() -> expression*
 
 auto parser::parse_null_literal() -> expression*
 {
-    return make<null_literal>(m_current_token.loc);
+    return allocate<null_literal>(m_current_token.loc);
 }
 
 auto parser::get(token_type type) -> bool
@@ -876,12 +876,12 @@ return 993322;
 TEST_CASE("string")
 {
     using enum token_type;
-    auto name = make<identifier>("myVar", location {"<stdin>", 1, 1});
-    auto value = make<identifier>("anotherVar", location {"<stdin>", 1, 9});
+    auto name = allocate<identifier>("myVar", location {"<stdin>", 1, 1});
+    auto value = allocate<identifier>("anotherVar", location {"<stdin>", 1, 9});
 
     program prgrm {location {"<stdin>", 1, 1}};
 
-    auto let_stmt = make<let_statement>(location {});
+    auto let_stmt = allocate<let_statement>(location {});
 
     let_stmt->name = name;
     let_stmt->value = value;

--- a/source/vm/vm.cpp
+++ b/source/vm/vm.cpp
@@ -29,13 +29,13 @@
 
 auto vm::create(bytecode code) -> vm
 {
-    return create_with_state(std::move(code), make<constants>(globals_size));
+    return create_with_state(std::move(code), allocate<constants>(globals_size));
 }
 
 auto vm::create_with_state(bytecode code, constants* globals) -> vm
 {
-    auto* main_fn = make<compiled_function_object>(std::move(code.instrs), 0, 0);
-    auto* main_closure = make<closure_object>(main_fn);
+    auto* main_fn = allocate<compiled_function_object>(std::move(code.instrs), 0, 0);
+    auto* main_closure = allocate<closure_object>(main_fn);
     const frame main_frame {.cl = main_closure};
     frames frms;
     frms[0] = main_frame;
@@ -200,7 +200,7 @@ auto vm::run() -> void
                 current_frame().ip += 1;
                 const auto builtin_index = instr[ip + 1UL];
                 const auto* const builtin = builtin::builtins()[builtin_index];
-                push(make<builtin_object>(builtin));
+                push(allocate<builtin_object>(builtin));
             } break;
             case opcodes::set_free: {
                 current_frame().ip += 1;
@@ -321,11 +321,11 @@ auto vm::exec_minus() -> void
 {
     const auto* operand = pop();
     if (operand->is(object::object_type::integer)) {
-        push(make<integer_object>(-operand->as<integer_object>()->value));
+        push(allocate<integer_object>(-operand->as<integer_object>()->value));
         return;
     }
     if (operand->is(object::object_type::decimal)) {
-        push(make<decimal_object>(-operand->as<decimal_object>()->value));
+        push(allocate<decimal_object>(-operand->as<decimal_object>()->value));
         return;
     }
 
@@ -366,7 +366,7 @@ auto vm::build_array(int start, int end) const -> const object*
     for (auto idx = start; idx < end; idx++) {
         arr.push_back(m_stack[idx]);
     }
-    return make<array_object>(std::move(arr));
+    return allocate<array_object>(std::move(arr));
 }
 
 auto vm::build_hash(int start, int end) const -> const object*
@@ -377,7 +377,7 @@ auto vm::build_hash(int start, int end) const -> const object*
         const auto* val = m_stack[idx + 1];
         hsh[key->as<hashable>()->hash_key()] = val;
     }
-    return make<hash_object>(std::move(hsh));
+    return allocate<hash_object>(std::move(hsh));
 }
 
 namespace
@@ -411,7 +411,7 @@ auto vm::exec_index(const object* left, const object* index) -> void
             push(null());
             return;
         }
-        push(make<string_object>(left->as<string_object>()->value.substr(static_cast<std::size_t>(idx), 1)));
+        push(allocate<string_object>(left->as<string_object>()->value.substr(static_cast<std::size_t>(idx), 1)));
         return;
     }
     if (left->is(hash) && index->is_hashable()) {
@@ -479,7 +479,7 @@ auto vm::push_closure(uint16_t const_idx, uint8_t num_free) -> void
         free.push_back(m_stack[m_sp - num_free + i]);
     }
     m_sp -= num_free;
-    push(make<closure_object>(constant->as<compiled_function_object>(), free));
+    push(allocate<closure_object>(constant->as<compiled_function_object>(), free));
 }
 
 namespace


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Rename the `make` function to `allocate`.