### PR TITLE
chore: Add node and sccache to void-linux-musl-clang

### DIFF
--- a/.github/docker/cappuchin-github-void-linux-musl-clang/Dockerfile
+++ b/.github/docker/cappuchin-github-void-linux-musl-clang/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/void-linux/void-musl@sha256:8184a64e38dfb5361f196465c3a2f3b31d43e5baa74cb66f49d5593ae81f3ba4
 RUN xbps-install -Syu || xbps-install -yu xbps \
     && xbps-install -yu \
-    && xbps-install -y bash clang clang-tools-extra cmake cppcheck git gzip jq ninja tar wget \
+    && xbps-install -y bash clang clang-tools-extra cmake cppcheck git gzip jq ninja tar wget node sccache \
     && xbps-remove -Ooy
 LABEL org.opencontainers.image.source="https://github.com/hrzlgnm/Cappuchin"
 LABEL org.opencontainers.image.title="Cappuchin GitHub Void Linux Musl Clang"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add Node.js and sccache packages to the Void Linux build container to expand build environment capabilities