### PR TITLE
chore: add bsdtar to github gcc builder

### DIFF
--- a/.github/docker/cappuchin-github-gcc/Dockerfile
+++ b/.github/docker/cappuchin-github-gcc/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/void-linux/void-glibc@sha256:433691c192e373ab9f328385798f9b2f837c7b4ed69ee2784889bfd6ea077409
 RUN xbps-install -Syu || xbps-install -yu xbps \
     && xbps-install -yu \
-    && xbps-install -y bash cmake gcc git libsanitizer-devel make ninja nodejs rust-sccache \
+    && xbps-install -y bash cmake gcc git libsanitizer-devel make ninja nodejs rust-sccache bsdtar \
     && xbps-remove -Ooy
 LABEL org.opencontainers.image.source="https://github.com/hrzlgnm/Cappuchin"
 LABEL org.opencontainers.image.title="Cappuchin GitHub GCC"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Install bsdtar package in the Dockerfile for the GitHub GCC builder image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated container dependencies to include an additional utility package for improved system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->