### PR TITLE
chore: add sccache to gcc 13 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,7 @@ jobs:
               CMAKE_BUILD_TYPE: "Debug",
               WARNINGS: "-Werror;{0}",
               CMAKE_FLAGS: "-G Ninja",
+              sccache: "sccache",
             }
           - {
               runs_on: ubuntu-latest,
@@ -147,6 +148,7 @@ jobs:
               WARNINGS: "-Werror;{0}",
               CMAKE_FLAGS: "-G Ninja",
               ASAN_OPTIONS: "strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
+              sccache: "sccache",
             }
           - {
               runs_on: ubuntu-latest,
@@ -158,6 +160,7 @@ jobs:
               CMAKE_BUILD_TYPE: "Release",
               WARNINGS: "-Werror;{0}",
               CMAKE_FLAGS: "-G Ninja",
+              sccache: "sccache",
             }
           - {
               runs_on: windows-latest,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:6c471dcad09facb42fde7b88ba2f1aaa8b5cf7b05e1237c0146c5acb897c5d2b",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:c99ba04817fb8e8459defd7617ae95689de1ac0341e4df7a16522be1aaf2b3fe",
               CC: gcc,
               CXX: g++,
               CFLAGS: "",
@@ -140,7 +140,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13 ASAN+UBSAN",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:6c471dcad09facb42fde7b88ba2f1aaa8b5cf7b05e1237c0146c5acb897c5d2b",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:c99ba04817fb8e8459defd7617ae95689de1ac0341e4df7a16522be1aaf2b3fe",
               CC: gcc,
               CXX: g++,
               CFLAGS: "-fsanitize=address,undefined -fsanitize-address-use-after-scope -fno-sanitize-recover=address,undefined -fuse-ld=gold",
@@ -153,7 +153,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13 Release",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:6c471dcad09facb42fde7b88ba2f1aaa8b5cf7b05e1237c0146c5acb897c5d2b",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:c99ba04817fb8e8459defd7617ae95689de1ac0341e4df7a16522be1aaf2b3fe",
               CC: gcc,
               CXX: g++,
               CFLAGS: "",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:39badac2d09fd89397958b884bf86d20af845a6bfaaab76b0be0e2557a3ee68f",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:6c471dcad09facb42fde7b88ba2f1aaa8b5cf7b05e1237c0146c5acb897c5d2b",
               CC: gcc,
               CXX: g++,
               CFLAGS: "",
@@ -140,7 +140,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13 ASAN+UBSAN",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:39badac2d09fd89397958b884bf86d20af845a6bfaaab76b0be0e2557a3ee68f",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:6c471dcad09facb42fde7b88ba2f1aaa8b5cf7b05e1237c0146c5acb897c5d2b",
               CC: gcc,
               CXX: g++,
               CFLAGS: "-fsanitize=address,undefined -fsanitize-address-use-after-scope -fno-sanitize-recover=address,undefined -fuse-ld=gold",
@@ -153,7 +153,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13 Release",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:39badac2d09fd89397958b884bf86d20af845a6bfaaab76b0be0e2557a3ee68f",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:6c471dcad09facb42fde7b88ba2f1aaa8b5cf7b05e1237c0146c5acb897c5d2b",
               CC: gcc,
               CXX: g++,
               CFLAGS: "",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:c99ba04817fb8e8459defd7617ae95689de1ac0341e4df7a16522be1aaf2b3fe",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:4cc9989abd08c3eb58433b3f155ce7965aa2690d0ea11f2a3cccc3dc813bdbc3",
               CC: gcc,
               CXX: g++,
               CFLAGS: "",
@@ -140,7 +140,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13 ASAN+UBSAN",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:c99ba04817fb8e8459defd7617ae95689de1ac0341e4df7a16522be1aaf2b3fe",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:4cc9989abd08c3eb58433b3f155ce7965aa2690d0ea11f2a3cccc3dc813bdbc3",
               CC: gcc,
               CXX: g++,
               CFLAGS: "-fsanitize=address,undefined -fsanitize-address-use-after-scope -fno-sanitize-recover=address,undefined -fuse-ld=gold",
@@ -153,7 +153,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13 Release",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:c99ba04817fb8e8459defd7617ae95689de1ac0341e4df7a16522be1aaf2b3fe",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:4cc9989abd08c3eb58433b3f155ce7965aa2690d0ea11f2a3cccc3dc813bdbc3",
               CC: gcc,
               CXX: g++,
               CFLAGS: "",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:4cc9989abd08c3eb58433b3f155ce7965aa2690d0ea11f2a3cccc3dc813bdbc3",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:9030ff556cb015384ffb0b41711680d039734d6add4b61b0edccc1fd7229e98b",
               CC: gcc,
               CXX: g++,
               CFLAGS: "",
@@ -140,7 +140,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13 ASAN+UBSAN",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:4cc9989abd08c3eb58433b3f155ce7965aa2690d0ea11f2a3cccc3dc813bdbc3",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:9030ff556cb015384ffb0b41711680d039734d6add4b61b0edccc1fd7229e98b",
               CC: gcc,
               CXX: g++,
               CFLAGS: "-fsanitize=address,undefined -fsanitize-address-use-after-scope -fno-sanitize-recover=address,undefined -fuse-ld=gold",
@@ -153,7 +153,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "GCC 13 Release",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:4cc9989abd08c3eb58433b3f155ce7965aa2690d0ea11f2a3cccc3dc813bdbc3",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-gcc:v1@sha256:9030ff556cb015384ffb0b41711680d039734d6add4b61b0edccc1fd7229e98b",
               CC: gcc,
               CXX: g++,
               CFLAGS: "",


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure sccache for multiple build configurations in GitHub Actions workflow to optimize build performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Optimized the build process by introducing improved caching support, resulting in faster and more reliable builds across multiple environments.
	- Updated container images for the build jobs to enhance performance and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->