### PR TITLE
chore: install tar and remove nodejs

### DIFF
--- a/.github/docker/cappuchin-github-gcc/Dockerfile
+++ b/.github/docker/cappuchin-github-gcc/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/void-linux/void-glibc@sha256:433691c192e373ab9f328385798f9b2f837c7b4ed69ee2784889bfd6ea077409
 RUN xbps-install -Syu || xbps-install -yu xbps \
     && xbps-install -yu \
-    && xbps-install -y bash cmake gcc git libsanitizer-devel make ninja nodejs rust-sccache bsdtar \
+    && xbps-install -y bash cmake gcc git libsanitizer-devel make ninja rust-sccache tar \
     && xbps-remove -Ooy
 LABEL org.opencontainers.image.source="https://github.com/hrzlgnm/Cappuchin"
 LABEL org.opencontainers.image.title="Cappuchin GitHub GCC"

--- a/.github/docker/cappuchin-github-void-linux-musl-clang/Dockerfile
+++ b/.github/docker/cappuchin-github-void-linux-musl-clang/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/void-linux/void-musl@sha256:8184a64e38dfb5361f196465c3a2f3b31d43e5baa74cb66f49d5593ae81f3ba4
 RUN xbps-install -Syu || xbps-install -yu xbps \
     && xbps-install -yu \
-    && xbps-install -y bash clang clang-tools-extra cmake cppcheck git gzip jq ninja tar wget nodejs rust-sccache bsdtar \
+    && xbps-install -y bash clang clang-tools-extra cmake cppcheck git gzip jq ninja tar wget rust-sccache tar \
     && xbps-remove -Ooy
 LABEL org.opencontainers.image.source="https://github.com/hrzlgnm/Cappuchin"
 LABEL org.opencontainers.image.title="Cappuchin GitHub Void Linux Musl Clang"


### PR DESCRIPTION
## Summary by Sourcery

Update Docker images by removing nodejs and ensuring tar is installed

Build:
- Ensure tar package is explicitly installed in Docker images

Chores:
- Modify Dockerfiles to remove nodejs package from installation list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Optimized the system environment setup by streamlining the package installation process. The update refines the dependencies installed during image creation, enhancing overall efficiency and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->