### PR TITLE
chore: Add docker image for building with clang 17 glibc

### DIFF
--- a/.github/docker/cappuchin-github-void-linux-glibc-clang/.dockerignore
+++ b/.github/docker/cappuchin-github-void-linux-glibc-clang/.dockerignore
@@ -1,0 +1,1 @@
+README.md

--- a/.github/docker/cappuchin-github-void-linux-glibc-clang/Dockerfile
+++ b/.github/docker/cappuchin-github-void-linux-glibc-clang/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/void-linux/void-glibc@sha256:433691c192e373ab9f328385798f9b2f837c7b4ed69ee2784889bfd6ea077409
+RUN xbps-install -Syu || xbps-install -yu xbps \
+    && xbps-install -yu \
+    && xbps-install -y bash clang clang-tools-extra cmake git gzip jq ninja tar wget \
+    && xbps-remove -Ooy
+LABEL org.opencontainers.image.source="https://github.com/hrzlgnm/Cappuchin"
+LABEL org.opencontainers.image.title="Cappuchin GitHub Void Linux Glibc Clang"
+LABEL org.opencontainers.image.base.name="ghcr.io/void-linux/void-glibc"
+LABEL org.opencontainers.image.base.digest="sha256:433691c192e373ab9f328385798f9b2f837c7b4ed69ee2784889bfd6ea077409"

--- a/.github/docker/cappuchin-github-void-linux-glibc-clang/README.md
+++ b/.github/docker/cappuchin-github-void-linux-glibc-clang/README.md
@@ -1,0 +1,17 @@
+# cappuchin-github-void-linux-glibc-clang Docker image
+
+## Updating the Docker image
+
+> [!NOTE]
+> This is usually not needed to be done manually, as the Docker image is automatically built and pushed
+> by the GitHub Actions workflow defined in the `.github/workflows/docker-build.yml` file.
+
+Pick a version number for the new Docker image (e.g. `v2`), then run the
+following commands:
+
+    $ docker build --tag ghcr.io/hrzlgnm/cappuchin-github-void-linux-glibc-clang:VERSION_NUMBER_HERE .github/docker/cappuchin-github-void-linux-glibc-clang/
+    $ docker login ghcr.io -u YOUR_GITHUB_USER_NAME_HERE
+    $ docker push ghcr.io/hrzlgnm/cappuchin-github-void-linux-glibc-clang:VERSION_NUMBER_HERE
+
+Then, change the container tag in each workflow file in the .github/workflows/
+directory to refer to your new version.


### PR DESCRIPTION
## Summary by Sourcery

Add a Docker image for building the project with Clang 17 and glibc on Void Linux

Build:
- Set up a Docker image with Clang, CMake, and other build tools on Void Linux glibc base image

CI:
- Add Docker image configuration for GitHub Actions build environment

Chores:
- Create a Dockerfile and README for a new build environment Docker image