### PR TITLE
chore: use default linker with clang 17 and musl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
               container_image: "ghcr.io/hrzlgnm/cappuchin-github-void-linux-musl-clang:v1@sha256:60c2ca638aeef5ebdfb078346eaa81e885d30da6d0ac9ab9905e8f5161fc6390",
               CC: clang,
               CXX: clang++,
-              CFLAGS: "-fsanitize=address,undefined -fsanitize-address-use-after-scope -fno-sanitize-recover=address,undefined -fuse-ld=gold",
+              CFLAGS: "-fsanitize=address,undefined -fsanitize-address-use-after-scope -fno-sanitize-recover=address,undefined",
               CMAKE_BUILD_TYPE: "Debug",
               WARNINGS: "-Werror;{1}",
               CMAKE_FLAGS: "-G Ninja",


### PR DESCRIPTION
## Summary by Sourcery

Update the linker configuration in the GitHub Actions workflow to use the LLD linker instead of the Gold linker for Musl builds

CI:
- Updated CFLAGS to use LLD linker (-fuse-ld=lld) in the Musl build environment

Chores:
- Changed the linker from Gold to LLD in the build workflow configuration