### PR TITLE
chore: Refactor build workflow to integrate JUnit reporting into Build-And-Test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,33 +271,15 @@ jobs:
         working-directory: ./build
         run: ctest --verbose --build-config ${{matrix.toolchain.CMAKE_BUILD_TYPE}}
 
-      - name: Upload test report artifacts (non musl)
-        if: ${{ !contains(matrix.toolchain.name, 'musl') }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: "${{ matrix.toolchain.name }}-junit-report"
-          path: |
-            build/test/doctest/junit.xml
-
-  JUnit:
-    needs: [Build-And-Test]
-    runs-on: ubuntu-latest
-    if: always()
-    container:
-      image: "ghcr.io/hrzlgnm/cappuchin-github-void-linux-glibc-clang:v1@sha256:fd73f6997d2a05eccae7360dbe86166eaf1f9bc1c970f261c31ce902e9a8711c"
-
-    steps:
-      - name: Download all produced artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-
-      - name: Create JUnit Report
-        if: always()
+      - name: JUnit Report
+        if: ${{ always() && !contains(matrix.toolchain.name, 'musl') }}
         uses: mikepenz/action-junit-report@a83fd2b5d58d4fc702e690c1ea688d702d28d281 # v5
         with:
           report_paths: "**/junit.xml"
           fail_on_parse_error: true
           require_tests: true
           include_passed: true
+          check_name: "${{ matrix.toolchain.name }} JUnit Report"
 
   Static-Analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved the build workflow by integrating JUnit report generation directly into the main build and test process.
	- Removed redundant steps and jobs for artifact handling and separate JUnit reporting.
	- JUnit reports are now generated more efficiently and consistently within the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->