### PR TITLE
chore(ci): Bump Clang and libc++ to 19 in CI Dockerfile and GH Actions matrix

### DIFF
--- a/.github/docker/cappuchin-github-clang/Dockerfile
+++ b/.github/docker/cappuchin-github-clang/Dockerfile
@@ -4,11 +4,11 @@ RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     build-essential \
     ca-certificates \
-    clang-17 \
+    clang-19 \
     cmake \
     git \
-    libc++-17-dev \
-    libc++abi-17-dev \
+    libc++-19-dev \
+    libc++abi-19-dev \
     libc6-dev \
     ninja-build && \
     rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,10 @@ jobs:
             }
           - {
               runs_on: ubuntu-latest,
-              name: "Clang 17 libc++",
+              name: "Clang 19 libc++",
               container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:0159484e6e5f112f1313935309b921faeadb8f5a787ca910387d5199812db169",
-              CC: clang-17,
-              CXX: clang++-17,
+              CC: clang-19,
+              CXX: clang++-19,
               CFLAGS: "-stdlib=libc++",
               CMAKE_BUILD_TYPE: "Debug",
               WARNINGS: "-Werror;{1}",
@@ -59,10 +59,10 @@ jobs:
             }
           - {
               runs_on: ubuntu-latest,
-              name: "Clang 17 libstdc++",
+              name: "Clang 19 libstdc++",
               container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:0159484e6e5f112f1313935309b921faeadb8f5a787ca910387d5199812db169",
-              CC: clang-17,
-              CXX: clang++-17,
+              CC: clang-19,
+              CXX: clang++-19,
               CFLAGS: "-stdlib=libstdc++",
               CMAKE_BUILD_TYPE: "Debug",
               WARNINGS: "-Werror;{1}",
@@ -71,10 +71,10 @@ jobs:
             }
           - {
               runs_on: ubuntu-latest,
-              name: "Clang 17 ASAN+UBSAN libstdc++",
+              name: "Clang 19 ASAN+UBSAN libstdc++",
               container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:0159484e6e5f112f1313935309b921faeadb8f5a787ca910387d5199812db169",
-              CC: clang-17,
-              CXX: clang++-17,
+              CC: clang-19,
+              CXX: clang++-19,
               CFLAGS: "-fsanitize=address,undefined -fsanitize-address-use-after-scope -fno-sanitize-recover=address,undefined -stdlib=libstdc++",
               CMAKE_BUILD_TYPE: "Debug",
               WARNINGS: "-Werror;{1}",
@@ -84,10 +84,10 @@ jobs:
             }
           - {
               runs_on: ubuntu-latest,
-              name: "Clang 17 Release libstdc++",
+              name: "Clang 19 Release libstdc++",
               container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:0159484e6e5f112f1313935309b921faeadb8f5a787ca910387d5199812db169",
-              CC: clang-17,
-              CXX: clang++-17,
+              CC: clang-19,
+              CXX: clang++-19,
               CFLAGS: "-stdlib=libstdc++",
               CMAKE_BUILD_TYPE: "Release",
               WARNINGS: "-Werror;{1}",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the compiler toolchain to Clang 19 across build environments.
  * Updated standard library packages to the 19 series in containerized builds.
  * Refreshed CI configurations to use Clang 19 for libc++, libstdc++, ASAN+UBSAN, and Release variants.

* **Tests**
  * CI build-and-test matrix now runs against the updated Clang 19 toolchain across all relevant configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->