### PR TITLE
chore: Add libasan8 and libclang-rt-dev to GitHub Clang Dockerfile

### DIFF
--- a/.github/docker/cappuchin-github-clang/Dockerfile
+++ b/.github/docker/cappuchin-github-clang/Dockerfile
@@ -7,9 +7,11 @@ RUN \
     clang-19 \
     cmake \
     git \
+    libasan8 \
     libc++-19-dev \
     libc++abi-19-dev \
     libc6-dev \
+    libclang-rt-dev \
     ninja-build && \
     rm -rf /var/lib/apt/lists/*
 LABEL org.opencontainers.image.source="https://github.com/hrzlgnm/Cappuchin"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the Clang-based Docker image used in GitHub workflows to include AddressSanitizer (libasan8) and Clang runtime libraries (libclang-rt-dev).
  - Expands available runtime libraries during CI builds and local runs that use this image, with no changes to the install sequence or other configurations.
  - No user-facing behavior changes; existing workflows should continue to run as before, aside from a modest increase in image size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->