### PR TITLE
chore(ci): Update GHA four Clang 19 matrix variants to new container image digest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "Clang 19 libc++",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:0159484e6e5f112f1313935309b921faeadb8f5a787ca910387d5199812db169",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:39fa5395c1a24950e1cce286596d9c07792a9f95d9efbdc318584370757f0e87",
               CC: clang-19,
               CXX: clang++-19,
               CFLAGS: "-stdlib=libc++",
@@ -60,7 +60,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "Clang 19 libstdc++",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:0159484e6e5f112f1313935309b921faeadb8f5a787ca910387d5199812db169",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:39fa5395c1a24950e1cce286596d9c07792a9f95d9efbdc318584370757f0e87",
               CC: clang-19,
               CXX: clang++-19,
               CFLAGS: "-stdlib=libstdc++",
@@ -72,7 +72,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "Clang 19 ASAN+UBSAN libstdc++",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:0159484e6e5f112f1313935309b921faeadb8f5a787ca910387d5199812db169",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:39fa5395c1a24950e1cce286596d9c07792a9f95d9efbdc318584370757f0e87",
               CC: clang-19,
               CXX: clang++-19,
               CFLAGS: "-fsanitize=address,undefined -fsanitize-address-use-after-scope -fno-sanitize-recover=address,undefined -stdlib=libstdc++",
@@ -85,7 +85,7 @@ jobs:
           - {
               runs_on: ubuntu-latest,
               name: "Clang 19 Release libstdc++",
-              container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:0159484e6e5f112f1313935309b921faeadb8f5a787ca910387d5199812db169",
+              container_image: "ghcr.io/hrzlgnm/cappuchin-github-clang:v1@sha256:39fa5395c1a24950e1cce286596d9c07792a9f95d9efbdc318584370757f0e87",
               CC: clang-19,
               CXX: clang++-19,
               CFLAGS: "-stdlib=libstdc++",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use the latest container images for Clang 19 configurations (libc++, libstdc++, ASAN/UBSAN, and Release).
  * Improves build consistency and stability across supported variants.
  * No changes to application features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->