### PR TITLE
chore: update to macos-13 due to deprecation of macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         toolchain:
           - {
-              runs_on: macos-13,
+              runs_on: macos-14,
               name: "macOS Clang",
               CC: clang,
               CXX: clang++,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS continuous integration runner to a newer environment version for improved build reliability and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->