### PR TITLE
chore(ci): Run examples in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,9 +279,9 @@ jobs:
           do
             echo "Running $n"
             if [[ "$(uname -s)" == "MINGW"* || "$(uname -s)" == "CYGWIN"* || "$(uname -s)" == "MSYS"* ]]; then
-              ./build/${{matrix.toolchain.CMAKE_BUILD_TYPE}}/cappuchin.exe "$n"
+              time ./build/${{matrix.toolchain.CMAKE_BUILD_TYPE}}/cappuchin.exe "$n"
             else
-              ./build/cappuchin "$n"
+              time ./build/cappuchin "$n"
             fi
           done
 


### PR DESCRIPTION
Closes #449 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs project examples as part of the build-and-test job, reporting progress and timing per example.
  * Two workflow steps were renamed to capitalized titles ("Build", "Test") with no functional change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->