### PR TITLE
chore(ci): Remove unused rust-sccache package

### DIFF
--- a/.github/docker/cappuchin-github-void-linux-glibc-clang/Dockerfile
+++ b/.github/docker/cappuchin-github-void-linux-glibc-clang/Dockerfile
@@ -13,7 +13,6 @@ RUN xbps-install -Syu xbps \
     jq \
     ninja \
     python3-pip \
-    rust-sccache \
     tar \
     wget \
     && xbps-remove -Ooy


### PR DESCRIPTION
We use sccache action which installs sccache on its own

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration by streamlining package dependencies, resulting in faster image builds with no impact on functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->