### PR TITLE
chore(ci): Fix tag of docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   changed-dockerfiles:
+    name: 🔍 Dockerfiles
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.packages.outputs.packages }}
@@ -39,6 +40,7 @@ jobs:
           echo "packages=$names" >> $GITHUB_OUTPUT
 
   build:
+    name: Build
     needs: changed-dockerfiles
     if: ${{ needs.changed-dockerfiles.outputs.packages != '[]' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified Docker image tag generation in the build workflow to use the event repository owner for both v1 and latest image tags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->